### PR TITLE
Workaround for smartcard login

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -54,4 +54,8 @@ package() {
   install -Dm644 "${srcdir}/${pkgname}/usr/share/doc/${pkgname/-sdp/}/copyright" "${pkgdir}/usr/share/licenses/${pkgname}/copyright"
   install -Dm644 "${srcdir}/${pkgname}/usr/share/doc/${pkgname/-sdp/}/LICENSE.github" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE.github"
   install -Dm644 "${srcdir}/${pkgname}/usr/share/doc/${pkgname/-sdp/}/LICENSES.chromium.html.bz2" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSES.chromium.html.bz2"
+
+  # pkcs#11 is either linked to or tries to dlopen() libdl.so.
+  # Install a symlink until Appgate Inc fixes this.
+  ln -s /usr/lib/libdl.so.2 "${pkgdir}/opt/appgate/service/libdl.so"
 }


### PR DESCRIPTION
glibc has stopped shipping /usr/lib/libdl.so. The pkcs#11 parts of the appgate sdp client is either linked to or dlopens() libdl.so instead of dlopen.so.2.